### PR TITLE
Build font into cache files after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Insert in `fonts.conf`
 </fontconfig>
 ```
 
+## Finalize Installation
+Build font into cache files
+```bash
+$ fc-cache -f
+```
+
 ## Installed!
 
 Check emojis here!


### PR DESCRIPTION
fc-cache is a useful command to run after installing new fonts. this ensures the font is stored in cache.